### PR TITLE
Split out parent classes to use in translator

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,10 @@ so my preferred style is to avoid pattern matches entirely.
 This also makes it possible to hide trait implementation subtypes
 (by using anonymous classes) where appropriate.
 
+`Leibniz#subst` represents that types are equal so in a sense it doesn't matter
+"which way round" it's used, but for consistency I would prefer to first substitute
+implicit parameters, then regular parameters, then self.
+
 As `paperdoll-core` is very abstract, a lot of tests for `paperdoll-core` code
 require one or more effect implementations.
 So I've moved those tests down into `paperdoll-all` rather than add test-only effects.

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ but make use of unsafe casts internally for performance.
  * Extend Translator support to cover many monad transformers
   * Allows some limited support for ReaderWriterState and friends
  * Finish paperdoll-doobie
- * Once scalaz 7.3 and shapeless 2.3.1 are released:
+ * Once scalaz 7.3 released:
   * Tighten up dependency config (i.e. not snapshots repo)
   * Tighten up PGP signature checking of upstream (i.e. specify key fingerprints)
  * Finish TODOs in this document (in particular examples)

--- a/arm/src/main/scala/paperdoll/arm/Region.scala
+++ b/arm/src/main/scala/paperdoll/arm/Region.scala
@@ -9,14 +9,15 @@ import paperdoll.core.layer.Layers
 import shapeless.Coproduct
 import scalaz.Leibniz.===
 import paperdoll.core.effect.Pure
+import paperdoll.core.effect.Handler
 import scalaz.Forall
 import paperdoll.core.effect.Arr_
 import paperdoll.core.effect.Arrs
 import paperdoll.core.effect.Impure
 import paperdoll.core.queue.Queue
-import paperdoll.core.effect.Bind
+import paperdoll.core.effect.PureBind
 import paperdoll.core.effect.Arr
-import paperdoll.core.effect.Handler
+import paperdoll.core.effect.PureHandler
 import shapeless.Nat
 
 sealed trait Region[S <: Nat, R, A] {
@@ -41,7 +42,7 @@ object Region {
         resource(Leibniz.refl, r)
     })
 
-  private[this] def handleInRgn[S <: Nat, RE](handle: RE)(implicit re: Resource[RE]) = new Bind[Region_[S, RE]] {
+  private[this] def handleInRgn[S <: Nat, RE](handle: RE)(implicit re: Resource[RE]) = new PureBind[Region_[S, RE]] {
     override type O[X] = X
     override def pure[A](a: A) = {
       re.close(handle)
@@ -51,23 +52,32 @@ object Region {
       throw new RuntimeException("Opened the same handle twice. Did you reuse the same S type for multiple regions?")
   }
 
-  def newRgn[S <: Nat, RE](implicit re: Resource[RE]): Handler[Region_[S, RE]] = new Handler[Region_[S, RE]] {
+  def newRgn[S <: Nat, RE](implicit re: Resource[RE]): PureHandler[Region_[S, RE]] = new PureHandler[Region_[S, RE]] {
     override type O[X] = X
-    override def run[R <: Coproduct, L1 <: Layers[R], A](eff: Effects[R, L1, A])(
-      implicit me: Member[R, Region_[S, RE]] { type L = L1 }): Effects[me.RestR, me.RestL, O[A]] =
-      eff.fold(
-        a => Pure[me.RestR, me.RestL, A](a),
-        new Forall[({ type K[X] = (me.L#O[X], Arrs[R, me.L, X, A]) ⇒ Effects[me.RestR, me.RestL, O[A]] })#K] {
-          override def apply[X] = { (eff, cont) ⇒
-            val composed = compose(cont)
-            me.remove(eff).fold(
-              otherEffect ⇒ Impure[me.RestR, me.RestL, X, O[A]](otherEffect, Queue.one[Arr_[me.RestR, me.RestL]#O, X, O[A]](
-                composed andThen { run(_) })),
-              _.fold({ (le, r) =>
-                re.open(r)
-                handleInRgn[S, RE](r).apply(le.subst[({ type K[Y] = Arr[R, L1, Y, A] })#K](composed)(r))
-              }))
-          }
-        })
+    override def handler[R <: Coproduct, L1 <: Layers[R]](implicit me1: Member[R, Region_[S, RE]]{type L = L1}): Handler[R, L1, Region_[S, RE]] {
+      type RestR = me1.RestR
+      type RestL = me1.RestL
+      type O[X] = X
+    } = new Handler[R, L1, Region_[S, RE]] {
+      type RestR = me1.RestR
+      type RestL = me1.RestL
+      type O[X] = X
+      def me = me1
+      override def run[A](eff: Effects[R, L1, A]): Effects[RestR, RestL, O[A]] =
+        eff.fold(
+          a ⇒ Pure[RestR, RestL, A](a),
+          new Forall[({ type K[X] = (L1#O[X], Arrs[R, L1, X, A]) ⇒ Effects[RestR, RestL, O[A]] })#K] {
+            override def apply[X] = { (eff, cont) ⇒
+              val composed = compose(cont)
+              me.remove(eff).fold(
+                otherEffect ⇒ Impure[RestR, RestL, X, O[A]](otherEffect, Queue.one[Arr_[RestR, RestL]#O, X, O[A]](
+                  composed andThen { run(_) })),
+                _.fold({ (le, r) ⇒
+                  re.open(r)
+                  handleInRgn[S, RE](r).apply(le.subst[({ type K[Y] = Arr[R, L1, Y, A] })#K](composed)(r))
+                }))
+            }
+          })
+    }
   }
 }

--- a/cats/src/main/scala/paperdoll/cats/XorLayer.scala
+++ b/cats/src/main/scala/paperdoll/cats/XorLayer.scala
@@ -2,10 +2,10 @@ package paperdoll.cats
 
 import cats.data.Xor
 import paperdoll.core.effect.Arr
-import paperdoll.core.effect.Handler
+import paperdoll.core.effect.PureHandler
 import shapeless.Coproduct
 import paperdoll.core.layer.Layers
-import paperdoll.core.effect.Bind
+import paperdoll.core.effect.PureBind
 import paperdoll.core.effect.Effects
 import paperdoll.core.effect.Pure
 import CatsEffects.sendUC
@@ -16,8 +16,8 @@ object XorLayer {
     /** Xor is handled much like Option: if \/-,
    *  run the continuation, if -\/, return that.
    */
-  def handleXor[A]: Handler.Aux[Xor_[A], Xor_[A]#F] =
-    new Bind[Xor_[A]] {
+  def handleXor[A]: PureHandler.Aux[Xor_[A], Xor_[A]#F] =
+    new PureBind[Xor_[A]] {
       override type O[X] = Xor[A, X]
       override def pure[B](b: B) = Xor.Right(b)
       override def bind[V, RR <: Coproduct, RL <: Layers[RR], B](

--- a/core/src/main/scala/paperdoll/core/effect/Bind.scala
+++ b/core/src/main/scala/paperdoll/core/effect/Bind.scala
@@ -2,10 +2,6 @@ package paperdoll.core.effect
 
 import paperdoll.core.layer.{ Layer, Layers }
 import shapeless.Coproduct
-import paperdoll.core.layer.Member
-import scalaz.Forall
-import paperdoll.core.queue.Queue
-import Arrs.compose
 
 trait Bind[R <: Coproduct, L1 <: Layers[R], L <: Layer] extends Handler[R, L1, L] with Loop[R, L1, L]
 

--- a/core/src/main/scala/paperdoll/core/effect/Bind.scala
+++ b/core/src/main/scala/paperdoll/core/effect/Bind.scala
@@ -7,33 +7,23 @@ import scalaz.Forall
 import paperdoll.core.queue.Queue
 import Arrs.compose
 
-/** The simplest/most common implementation of Handler,
- *  supplying implementations for pure and bind
- */
-trait Bind[L <: Layer] extends Handler[L] {
-  /** How the type of the value is transformed by handling this effect
-   */
-  type O[X]
+trait Bind[R <: Coproduct, L1 <: Layers[R], L <: Layer] extends Handler[R, L1, L] with Loop[R, L1, L]
 
-  /** Translate the pure value a
-   */
+trait PureBind[L <: Layer] extends PureHandler[L] {
   def pure[A](a: A): O[A]
-  /** Translate the effectful value eff (with an effect from layer L)
-   *  and effectful continuation cont (V => A with effects R)
-   *  into an effectful (lazy) value of type A
-   *  (usually by somehow "running" eff to obtain a V
-   *  and then passing it to cont)
-   */
   def bind[V, RR <: Coproduct, RL <: Layers[RR], A](eff: L#F[V], cont: Arr[RR, RL, V, O[A]]): Effects[RR, RL, O[A]]
 
-  final override def run[R <: Coproduct, L1 <: Layers[R], A](eff: Effects[R, L1, A])(implicit me: Member[R, L] { type L = L1 }): Effects[me.RestR, me.RestL, O[A]] =
-    eff.fold({ a ⇒ Pure[me.RestR, me.RestL, O[A]](pure(a)) }, new Forall[({ type K[X] = (me.L#O[X], Arrs[R, me.L, X, A]) ⇒ Effects[me.RestR, me.RestL, O[A]] })#K] {
-      override def apply[X] = { (eff, cont) ⇒
-        //New continuation is: recursively run this handler on the result of the old continuation 
-        val newCont = compose(cont) andThen { run(_) }
-        me.remove(eff).fold(
-          otherEffect ⇒ Impure[me.RestR, me.RestL, X, O[A]](otherEffect, Queue.one[Arr_[me.RestR, me.RestL]#O, X, O[A]](newCont)),
-          thisEffect ⇒ bind[X, me.RestR, me.RestL, A](thisEffect, newCont))
-      }
-    })
+  override def handler[R <: Coproduct, L1 <: Layers[R]](implicit me1: Member[R, L] { type L = L1 }): Handler[R, L1, L] {
+    type RestR = me1.RestR
+    type RestL = me1.RestL
+    type O[X] = PureBind.this.O[X]
+  } =
+    new Bind[R, L1, L] {
+      type RestR = me1.RestR
+      type RestL = me1.RestL
+      override def me = me1
+      override def pure[A](a: A) = PureBind.this.pure(a)
+      override type O[X] = PureBind.this.O[X]
+      override def bind[V, A](eff: L#F[V], cont: Arr[RestR, RestL, V, O[A]]) = PureBind.this.bind(eff, cont)
+    }
 }

--- a/core/src/main/scala/paperdoll/core/effect/Bind.scala
+++ b/core/src/main/scala/paperdoll/core/effect/Bind.scala
@@ -2,6 +2,7 @@ package paperdoll.core.effect
 
 import paperdoll.core.layer.{ Layer, Layers }
 import shapeless.Coproduct
+import paperdoll.core.layer.Member
 
 trait Bind[R <: Coproduct, L1 <: Layers[R], L <: Layer] extends Handler[R, L1, L] with Loop[R, L1, L]
 

--- a/core/src/main/scala/paperdoll/core/effect/Effects.scala
+++ b/core/src/main/scala/paperdoll/core/effect/Effects.scala
@@ -63,7 +63,7 @@ sealed trait Effects[R <: Coproduct, L <: Layers[R], A] {
   /** This is a "shallow" catamorphism. In practice the main use cases for this are recursive,
    *  folding all the way down, but I found it very difficult to express the required type
    *  for that case.
-   *  While calling directly is supported, the most common use case for this is covered by Bind.
+   *  While calling directly is supported, the most common use case for this is covered by PureBind.
    */
   def fold[B](pure: A ⇒ B, impure: Forall[({ type K[X] = (L#O[X], Arrs[R, L, X, A]) ⇒ B })#K]): B
 

--- a/core/src/main/scala/paperdoll/core/effect/Handler.scala
+++ b/core/src/main/scala/paperdoll/core/effect/Handler.scala
@@ -1,35 +1,62 @@
 package paperdoll.core.effect
 
-import scalaz.Leibniz
 import paperdoll.core.layer.Member
-import shapeless.Coproduct
 import paperdoll.core.layer.Layer
 import paperdoll.core.layer.Layers
+import shapeless.Coproduct
+import scalaz.Leibniz
 
-/**
- * Handler for the effect L: given an effectful value in a
- * stack of effects R containing L, return an effectful value
- * in the stack with L removed.
- * This is purely an implementation helper - it's possible to
- * handle a concrete effectful value directly (using Effects#fold)
- * but this interface makes the type inference easier
- * and supports the common use case of instantiating a handler
- * for a specific layer separately from applying it to a stack
- * of layers that contains that layer
- * TODO: unify with Translator as far as possible
+/** A class that can handle the effect represented by L in the stack R, L1.
+ *  This is purely an implementation helper - any subclasses could also be
+ *  written directly using Effects#fold.
+ *  This is still quite low-level - most common use cases are covered by
+ *  PureBind and/or Translator
  */
-trait Handler[L <: Layer] {
-  type O[X]
-  /**
-   * Actual implementation - apply method has extra Leibniz to assist type inference.
+trait Handler[R <: Coproduct, L1 <: Layers[R], L <: Layer] {
+  type RestR <: Coproduct
+  type RestL <: Layers[RestR]
+  /** "Output" type if we want to handle a layer by changing the value A.
+   *  E.g. we can translate an Option_ effect into a stack without that effect, but
+   *  where the value "inside" is an Option.
+   *  It is also common to have O=Id if we handle the effect by translating
+   *  it into another effect in the stack, or if the effect is handled in a way
+   *  that isn't exposed at the type level (e.g. via mutable state).
+   *  Really O should be allowed to be an arbitrary type-level function of X,
+   *  but there is no elegant way to encode that in Scala.
    */
-  def run[R <: Coproduct, L1 <: Layers[R], A](eff: Effects[R, L1, A])(implicit me: Member[R, L] { type L = L1 }): Effects[me.RestR, me.RestL, O[A]]
-  final def apply[R <: Coproduct, L1 <: Layers[R], A, L2 <: Layers[R]](eff: Effects[R, L1, A])(implicit me: Member[R, L] { type L = L2 },
-    le: Leibniz[Nothing, Layers[R], L1, L2]): Effects[me.RestR, me.RestL, O[A]] =
-    run(le.subst[({ type L[X <: Layers[R]] = Effects[R, X, A] })#L](eff))(me)
+  type O[X]
+  
+  def me: Member[R, L] {
+    type L = L1
+    type RestR = Handler.this.RestR
+    type RestL = Handler.this.RestL
+  }
+
+  /** Handle the layer L in eff, returning a new Effects for a smaller stack
+   *  (and possibly a transformed value).
+   */
+  def run[A](eff: Effects[R, L1, A]): Effects[RestR, RestL, O[A]]
+
 }
-object Handler {
-  type Aux[L <: Layer, O0[_]] = Handler[L] {
+
+trait PureHandler[L <: Layer] {
+  type O[X]
+  def handler[R <: Coproduct, L1 <: Layers[R]](implicit me1: Member[R, L] { type L = L1 }): Handler[R, L1, L] {
+    type RestR = me1.RestR
+    type RestL = me1.RestL
+    type O[X] = PureHandler.this.O[X]
+  }
+  final def apply[R <: Coproduct, L1 <: Layers[R], A, L2 <: Layers[R]](eff: Effects[R, L1, A])(
+    implicit me: Member[R, L] { type L = L2 },
+    le: Leibniz[Nothing, Layers[R], L2, L1]): Effects[me.RestR, me.RestL, O[A]] =
+    handler[R, L1](le.subst[({type K[X] = Member[R, L] {
+      type L = X
+      type RestR = me.RestR
+      type RestL = me.RestL
+    }})#K](me)).run(eff)
+}
+object PureHandler {
+  type Aux[L <: Layer, O0[_]] = PureHandler[L] {
     type O[X] = O0[X]
   }
 }

--- a/core/src/main/scala/paperdoll/core/effect/Handler.scala
+++ b/core/src/main/scala/paperdoll/core/effect/Handler.scala
@@ -10,7 +10,7 @@ import scalaz.Leibniz
  *  This is purely an implementation helper - any subclasses could also be
  *  written directly using Effects#fold.
  *  This is still quite low-level - most common use cases are covered by
- *  PureBind and/or Translator
+ *  PureBind and/or PureTranslator
  */
 trait Handler[R <: Coproduct, L1 <: Layers[R], L <: Layer] {
   type RestR <: Coproduct

--- a/core/src/main/scala/paperdoll/core/effect/Loop.scala
+++ b/core/src/main/scala/paperdoll/core/effect/Loop.scala
@@ -1,0 +1,51 @@
+package paperdoll.core.effect
+
+import paperdoll.core.layer.Layers
+import paperdoll.core.layer.Member
+import paperdoll.core.layer.Layer
+import scalaz.Forall
+import shapeless.Coproduct
+import paperdoll.core.queue.Queue
+import Arrs.compose
+
+/** Implementation helper for a common pattern in handling Effect layers.
+ *  This is still quite low-level - most common use cases are covered by
+ *  Handler and/or Translator.
+ */
+abstract class Loop[R <: Coproduct, L1 <: Layers[R], L <: Layer](implicit val me: Member[R, L] { type L = L1 }) {
+  /**
+   * "Output" type if we want to handle a layer by somehow "translating" the value A.
+   * E.g. we can translate an Option_ effect into a stack without that effect, but
+   * where the value "inside" is an Option.
+   * We really want to allow arbitrary type-level functions here, but the overhead of
+   * doing that in Scala doesn't seem worthwhile without convincing use cases.
+   */
+  type O[X]
+
+  /**
+   * Wrap up a pure value as an O[A]. Since any effectful stack might actually just
+   * be a pure value a, if we're translating into O[A] we need to be able to translate pure values
+   */
+  def pure[A](a: A): O[A]
+  
+  /**
+   * Handle a single effect eff and a continuation that's already been handled.
+   * This is the "meat" (and the reason Loop has to be different for each possible L type).
+   */
+  def bind[V, A](eff: L#F[V], cont: Arr[me.RestR, me.RestL, V, O[A]]): Effects[me.RestR, me.RestL, O[A]]
+
+  /**
+   * Loop through eff handling the layer L, returning an O[A] in a smaller effect stack.
+   */
+  final def run[A](eff: Effects[R, L1, A]): Effects[me.RestR, me.RestL, O[A]] =
+    eff.fold({ a ⇒ Pure[me.RestR, me.RestL, O[A]](pure(a)) },
+      new Forall[({ type K[X] = (me.L#O[X], Arrs[R, me.L, X, A]) ⇒ Effects[me.RestR, me.RestL, O[A]] })#K] {
+        override def apply[X] = { (eff, cont) ⇒
+          //New continuation is: recursively run this handler on the result of the old continuation 
+          val newCont = compose(cont) andThen { run(_) }
+          me.remove(eff).fold(
+            otherEffect ⇒ Impure[me.RestR, me.RestL, X, O[A]](otherEffect, Queue.one[Arr_[me.RestR, me.RestL]#O, X, O[A]](newCont)),
+            thisEffect ⇒ bind[X, A](thisEffect, newCont))
+        }
+      })
+}

--- a/core/src/main/scala/paperdoll/core/effect/Loop.scala
+++ b/core/src/main/scala/paperdoll/core/effect/Loop.scala
@@ -14,7 +14,7 @@ import Arrs.compose
  *  Purely an implementation helper - anything done with this could be done
  *  by calling Effects#fold directly.
  *  This is still quite low-level - most common use cases are covered by
- *  PureBind and/or Translator.
+ *  PureBind and/or PureTranslator.
  */
 trait Loop[R <: Coproduct, L1 <: Layers[R], L <: Layer] extends Handler[R, L1, L] {
 

--- a/core/src/main/scala/paperdoll/core/effect/Loop.scala
+++ b/core/src/main/scala/paperdoll/core/effect/Loop.scala
@@ -8,43 +8,37 @@ import shapeless.Coproduct
 import paperdoll.core.queue.Queue
 import Arrs.compose
 
-/** Implementation helper for a common pattern in handling Effect layers.
+/** TODO update
+ *  Handle an effect layer that works by recursively handling subsequent effects,
+ *  and having some method to compose an effect with a continuation in which
+ *  	subsequent cases of that effect have been handled.
+ *  Purely an implementation helper - anything done with this could be done
+ *  by calling Effects#fold directly.
  *  This is still quite low-level - most common use cases are covered by
- *  Handler and/or Translator.
+ *  PureBind and/or Translator.
  */
-abstract class Loop[R <: Coproduct, L1 <: Layers[R], L <: Layer](implicit val me: Member[R, L] { type L = L1 }) {
-  /**
-   * "Output" type if we want to handle a layer by somehow "translating" the value A.
-   * E.g. we can translate an Option_ effect into a stack without that effect, but
-   * where the value "inside" is an Option.
-   * We really want to allow arbitrary type-level functions here, but the overhead of
-   * doing that in Scala doesn't seem worthwhile without convincing use cases.
-   */
-  type O[X]
+trait Loop[R <: Coproduct, L1 <: Layers[R], L <: Layer] extends Handler[R, L1, L] {
 
-  /**
-   * Wrap up a pure value as an O[A]. Since any effectful stack might actually just
-   * be a pure value a, if we're translating into O[A] we need to be able to translate pure values
+  /** Wrap up a pure value as an O[A]. Since any effectful stack might actually just
+   *  be a pure value a, if we're translating into O[A] we need to be able to translate pure values
    */
   def pure[A](a: A): O[A]
-  
-  /**
-   * Handle a single effect eff and a continuation that's already been handled.
-   * This is the "meat" (and the reason Loop has to be different for each possible L type).
-   */
-  def bind[V, A](eff: L#F[V], cont: Arr[me.RestR, me.RestL, V, O[A]]): Effects[me.RestR, me.RestL, O[A]]
 
-  /**
-   * Loop through eff handling the layer L, returning an O[A] in a smaller effect stack.
+  /** Handle a single effect eff and a continuation that's already been handled.
+   *  This is the "meat" (and the reason Loop has to be different for each possible L type).
    */
-  final def run[A](eff: Effects[R, L1, A]): Effects[me.RestR, me.RestL, O[A]] =
-    eff.fold({ a ⇒ Pure[me.RestR, me.RestL, O[A]](pure(a)) },
-      new Forall[({ type K[X] = (me.L#O[X], Arrs[R, me.L, X, A]) ⇒ Effects[me.RestR, me.RestL, O[A]] })#K] {
+  def bind[V, A](eff: L#F[V], cont: Arr[RestR, RestL, V, O[A]]): Effects[RestR, RestL, O[A]]
+
+  /** Loop through eff handling the layer L, returning an O[A] in a smaller effect stack.
+   */
+  final def run[A](eff: Effects[R, L1, A]): Effects[RestR, RestL, O[A]] =
+    eff.fold({ a ⇒ Pure[RestR, RestL, O[A]](pure(a)) },
+      new Forall[({ type K[X] = (L1#O[X], Arrs[R, L1, X, A]) ⇒ Effects[RestR, RestL, O[A]] })#K] {
         override def apply[X] = { (eff, cont) ⇒
           //New continuation is: recursively run this handler on the result of the old continuation 
           val newCont = compose(cont) andThen { run(_) }
           me.remove(eff).fold(
-            otherEffect ⇒ Impure[me.RestR, me.RestL, X, O[A]](otherEffect, Queue.one[Arr_[me.RestR, me.RestL]#O, X, O[A]](newCont)),
+            otherEffect ⇒ Impure[RestR, RestL, X, O[A]](otherEffect, Queue.one[Arr_[RestR, RestL]#O, X, O[A]](newCont)),
             thisEffect ⇒ bind[X, A](thisEffect, newCont))
         }
       })

--- a/core/src/main/scala/paperdoll/core/effect/Loop.scala
+++ b/core/src/main/scala/paperdoll/core/effect/Loop.scala
@@ -1,7 +1,6 @@
 package paperdoll.core.effect
 
 import paperdoll.core.layer.Layers
-import paperdoll.core.layer.Member
 import paperdoll.core.layer.Layer
 import scalaz.Forall
 import shapeless.Coproduct

--- a/core/src/main/scala/paperdoll/core/effect/Translator.scala
+++ b/core/src/main/scala/paperdoll/core/effect/Translator.scala
@@ -7,7 +7,7 @@ import paperdoll.core.layer.Layer
 import paperdoll.core.layer.Layers
 import paperdoll.core.layer.Subset
 
-trait Translator[L <: Layer] {
+trait PureTranslator[L <: Layer] {
   type OR <: Coproduct
   type OL <: Layers[OR]
   /** Actual implementation - apply method has extra Leibniz to assist type inference.
@@ -42,8 +42,8 @@ trait Translator[L <: Layer] {
       }
     })#K](su))
 }
-object Translator {
-  type Aux[L <: Layer, OR0 <: Coproduct, OL0 <: Layers[OR0]] = Translator[L] {
+object PureTranslator {
+  type Aux[L <: Layer, OR0 <: Coproduct, OL0 <: Layers[OR0]] = PureTranslator[L] {
     type OR = OR0
     type OL = OL0
   }

--- a/core/src/main/scala/paperdoll/core/effect/Translator.scala
+++ b/core/src/main/scala/paperdoll/core/effect/Translator.scala
@@ -10,9 +10,7 @@ import paperdoll.core.layer.Subset
 trait PureTranslator[L <: Layer] {
   type OR <: Coproduct
   type OL <: Layers[OR]
-  /** Actual implementation - apply method has extra Leibniz to assist type inference.
-   */
-  def run[R <: Coproduct, L1 <: Layers[R], RR <: Coproduct, RL <: Layers[RR], A](eff: Effects[R, L1, A])(
+  def handler[R <: Coproduct, L1 <: Layers[R], RR <: Coproduct, RL <: Layers[RR]](
     implicit me: Member[R, L] {
       type L = L1
       type RestR = RR
@@ -21,7 +19,11 @@ trait PureTranslator[L <: Layer] {
     su: Subset[RR, OR] {
       type LT = OL
       type LS = RL
-    }): Effects[me.RestR, me.RestL, A]
+    }): Handler[R, L1, L] {
+    type RestR = RR
+    type RestL = RL
+    type O[X] = X
+  }
   final def apply[R <: Coproduct, L1 <: Layers[R], A, L2 <: Layers[R], RR <: Coproduct, RL <: Layers[RR], LT0 <: Layers[OR]](
     eff: Effects[R, L1, A])(implicit me: Member[R, L] {
       type L = L2
@@ -32,15 +34,20 @@ trait PureTranslator[L <: Layer] {
         type LS = RL
         type LT = LT0
       },
-      //FIXME: inconsistent in which way I substitute, should resolve this generally
-      le1: Leibniz[Nothing, Layers[R], L1, L2],
-      le2: Leibniz[Nothing, Layers[OR], LT0, OL]): Effects[me.RestR, me.RestL, A] =
-    run(le1.subst[({ type K[X <: Layers[R]] = Effects[R, X, A] })#K](eff))(me, le2.subst[({
+      le1: Leibniz[Nothing, Layers[R], L2, L1],
+      le2: Leibniz[Nothing, Layers[OR], LT0, OL]): Effects[RR, RL, A] =
+    handler[R, L1, RR, RL](le1.subst[
+      ({type K[X] = Member[R, L] {
+        type L = X
+        type RestR = RR
+        type RestL = RL
+      }})#K  
+    ](me), le2.subst[({
       type K[X <: Layers[OR]] = Subset[RR, OR] {
         type LS = RL
         type LT = X
       }
-    })#K](su))
+    })#K](su)).run(eff)
 }
 object PureTranslator {
   type Aux[L <: Layer, OR0 <: Coproduct, OL0 <: Layers[OR0]] = PureTranslator[L] {

--- a/core/src/main/scala/paperdoll/core/nondeterminism/Nondeterminism.scala
+++ b/core/src/main/scala/paperdoll/core/nondeterminism/Nondeterminism.scala
@@ -14,8 +14,9 @@ import scalaz.syntax.std.list._
 import paperdoll.core.queue.Queue
 import paperdoll.core.effect.Arr
 import scalaz.syntax.monad._
-import paperdoll.core.effect.Bind
-import paperdoll.core.effect.Handler
+import paperdoll.core.effect.PureBind
+import paperdoll.core.effect.PureHandler
+import paperdoll.core.effect.PureBind
 import scalaz.Foldable
 import scalaz.Unapply
 import scala.Vector
@@ -104,7 +105,7 @@ object Nondeterminism {
   /** Example interpreter. The paper implements this for any F[_]: Alternative
    *  rather than just Vector
    */
-  def runNDetVector: Handler.Aux[NDet_, Vector] = new Bind[NDet_] {
+  def runNDetVector: PureHandler.Aux[NDet_, Vector] = new PureBind[NDet_] {
     override type O[X] = Vector[X]
     override def pure[A](a: A) = Vector(a)
     override def bind[V, RR <: Coproduct, RL <: Layers[RR], A](eff: Nondeterminism[V], cont: Arr[RR, RL, V, Vector[A]]) =

--- a/pom.xml
+++ b/pom.xml
@@ -194,7 +194,7 @@
 			<dependency>
 				<groupId>com.chuusai</groupId>
 				<artifactId>shapeless_2.11</artifactId>
-				<version>2.3.1-SNAPSHOT</version>
+				<version>2.3.1-RC1</version>
 			</dependency>
 			<dependency>
 				<groupId>org.typelevel</groupId>

--- a/scalaz/src/main/scala/paperdoll/scalaz/DisjunctionLayer.scala
+++ b/scalaz/src/main/scala/paperdoll/scalaz/DisjunctionLayer.scala
@@ -1,11 +1,11 @@
 package paperdoll.scalaz
 
 import paperdoll.core.effect.Arr
-import paperdoll.core.effect.Handler
+import paperdoll.core.effect.PureHandler
 import paperdoll.core.effect.Pure
 import shapeless.Coproduct
 import paperdoll.core.layer.Layers
-import paperdoll.core.effect.Bind
+import paperdoll.core.effect.PureBind
 import scalaz.{ -\/, \/-, Disjunction }
 import paperdoll.core.effect.Effects.sendU
 import paperdoll.core.effect.Effects
@@ -16,8 +16,8 @@ object DisjunctionLayer {
   /** Disjunction is handled much like Option: if \/-,
    *  run the continuation, if -\/, return that.
    */
-  def handleDisjunction[A]: Handler.Aux[Disjunction_[A], Disjunction_[A]#F] =
-    new Bind[Disjunction_[A]] {
+  def handleDisjunction[A]: PureHandler.Aux[Disjunction_[A], Disjunction_[A]#F] =
+    new PureBind[Disjunction_[A]] {
       override type O[X] = Disjunction[A, X]
       override def pure[B](b: B) = \/-(b)
       override def bind[V, RR <: Coproduct, RL <: Layers[RR], B](

--- a/scalaz/src/main/scala/paperdoll/scalaz/ReaderLayer.scala
+++ b/scalaz/src/main/scala/paperdoll/scalaz/ReaderLayer.scala
@@ -2,7 +2,7 @@ package paperdoll.scalaz
 
 import shapeless.Coproduct
 import paperdoll.core.layer.Layers
-import paperdoll.core.effect.{ Effects, Arr, Bind, Handler }
+import paperdoll.core.effect.{ Effects, Arr, PureBind, PureHandler }
 import paperdoll.core.effect.Effects.sendU
 import scalaz.Id.Id
 import scalaz.Reader
@@ -20,7 +20,7 @@ object ReaderLayer {
    *  (i.e. giving the value i to any reads in the "lazy effectful value" e),
    *  removing Reader_[I] from the stack of effects in the result.
    */
-  def handleReader[I](i: I): Handler.Aux[Reader_[I], Id] = new Bind[Reader_[I]] {
+  def handleReader[I](i: I): PureHandler.Aux[Reader_[I], Id] = new PureBind[Reader_[I]] {
     override type O[X] = X
     override def pure[A](a: A) = a
     override def bind[V, RR <: Coproduct, RL <: Layers[RR], A](reader: Reader[I, V], arr: Arr[RR, RL, V, A]) =

--- a/scalaz/src/main/scala/paperdoll/scalaz/StateLayer.scala
+++ b/scalaz/src/main/scala/paperdoll/scalaz/StateLayer.scala
@@ -4,7 +4,7 @@ import scalaz.State
 import paperdoll.core.effect.Effects
 import paperdoll.core.effect.Effects.sendU
 import paperdoll.core.effect.Arrs.compose
-import paperdoll.core.effect.Handler
+import paperdoll.core.effect.{ PureHandler, Handler }
 import shapeless.Coproduct
 import paperdoll.core.layer.Layers
 import paperdoll.core.layer.Member
@@ -19,24 +19,37 @@ object StateLayer {
   def sendState[S, A](state: State[S, A]): Effects.One[State_[S], A] =
     sendU(state)
 
-  def handleState[S](initialState: S): Handler[State_[S]] {
-    type O[A] = (S, A)
-  } = new Handler[State_[S]] {
-    type O[A] = (S, A)
-    override def run[R <: Coproduct, L1 <: Layers[R], A](eff: Effects[R, L1, A])(
-      implicit me: Member[R, State_[S]] { type L = L1 }): Effects[me.RestR, me.RestL, (S, A)] =
-      eff.fold({ a ⇒ Pure[me.RestR, me.RestL, (S, A)]((initialState, a)) },
-        new Forall[({ type K[X] = (me.L#O[X], Arrs[R, me.L, X, A]) ⇒ Effects[me.RestR, me.RestL, (S, A)] })#K] {
-          override def apply[X] = { (eff, cont) ⇒
-            def newCont(newState: S) = compose(cont) andThen { handleState(newState).run(_) }
-            me.remove(eff).fold(
-              otherEffect ⇒ Impure[me.RestR, me.RestL, X, (S, A)](otherEffect,
-                Queue.one[Arr_[me.RestR, me.RestL]#O, X, O[A]](newCont(initialState))),
-              { stateEffect ⇒
-                val (newState, result) = stateEffect(initialState)
-                newCont(newState)(result)
-              })
-          }
-        })
+  private[this] class StateHandler[S](initialState: S) extends PureHandler[State_[S]] {
+    type O[X] = (S, X)
+    override def handler[R <: Coproduct, L1 <: Layers[R]](implicit me1: Member[R, State_[S]] {
+      type L = L1
+    }): Handler[R, L1, State_[S]] {
+      type RestR = me1.RestR
+      type RestL = me1.RestL
+      type O[X] = StateHandler.this.O[X]
+    } = new Handler[R, L1, State_[S]] {
+      override type RestR = me1.RestR
+      override type RestL = me1.RestL
+      override type O[X] = StateHandler.this.O[X]
+      override def me = me1
+      override def run[A](eff: Effects[R, L1, A]): Effects[RestR, RestL, (S, A)] =
+        eff.fold({ a ⇒ Pure[RestR, RestL, (S, A)]((initialState, a)) },
+          new Forall[({ type K[X] = (L1#O[X], Arrs[R, L1, X, A]) ⇒ Effects[RestR, RestL, (S, A)] })#K] {
+            override def apply[X] = { (eff, cont) ⇒
+              def newCont(newState: S) = compose(cont) andThen { handleState(newState).handler(me1).run(_) }
+              me.remove(eff).fold(
+                otherEffect ⇒ Impure[RestR, RestL, X, (S, A)](otherEffect,
+                  Queue.one[Arr_[RestR, RestL]#O, X, O[A]](newCont(initialState))),
+                { stateEffect ⇒
+                  val (newState, result) = stateEffect(initialState)
+                  newCont(newState)(result)
+                })
+            }
+          })
+    }
   }
+
+  def handleState[S](initialState: S): PureHandler[State_[S]] {
+    type O[A] = (S, A)
+  } = new StateHandler(initialState)
 }

--- a/scalaz/src/main/scala/paperdoll/scalaz/WriterLayer.scala
+++ b/scalaz/src/main/scala/paperdoll/scalaz/WriterLayer.scala
@@ -2,7 +2,7 @@ package paperdoll.scalaz
 
 import shapeless.{ :+:, CNil, Coproduct }
 import scalaz.{ Monoid, Writer }
-import paperdoll.core.effect.{ Effects, Arr, Bind, Handler }
+import paperdoll.core.effect.{ Effects, Arr, PureBind, PureHandler }
 import paperdoll.core.effect.Effects.sendU
 import paperdoll.core.effect.Arrs.compose
 import paperdoll.core.layer.Layers
@@ -29,9 +29,9 @@ object WriterLayer {
 
   /** Run the writer effect, producing a collection of all the written values
    */
-  def handleWriterCollection[W, CC <: TraversableOnce[W]](implicit cbf: CanBuildFrom[CC, W, CC]): Handler[Writer_[W]] {
+  def handleWriterCollection[W, CC <: TraversableOnce[W]](implicit cbf: CanBuildFrom[CC, W, CC]): PureHandler[Writer_[W]] {
     type O[X] = (CC, X)
-  } = new Bind[Writer_[W]] {
+  } = new PureBind[Writer_[W]] {
     override type O[X] = (CC, X)
     override def pure[A](a: A) = (cbf().result, a)
     override def bind[V, RR <: Coproduct, RL <: Layers[RR], A](writer: Writer[W, V], arr: Arr[RR, RL, V, (CC, A)]) = {
@@ -44,9 +44,9 @@ object WriterLayer {
    *  Notice how we can have multiple interpreters for the same effect,
    *  as we've decoupled the declaration of an effect from its implementation.
    */
-  def handleWriterMonoid[W](implicit monoid: Monoid[W]): Handler[Writer_[W]] {
+  def handleWriterMonoid[W](implicit monoid: Monoid[W]): PureHandler[Writer_[W]] {
     type O[X] = (W, X)
-  } = new Bind[Writer_[W]] {
+  } = new PureBind[Writer_[W]] {
     override type O[X] = (W, X)
     override def pure[A](a: A) = (monoid.zero, a)
     override def bind[V, RR <: Coproduct, RL <: Layers[RR], A](writer: Writer[W, V], arr: Arr[RR, RL, V, O[A]]) = {

--- a/scalaz/src/main/scala/paperdoll/scalaz/WriterLayer.scala
+++ b/scalaz/src/main/scala/paperdoll/scalaz/WriterLayer.scala
@@ -10,7 +10,7 @@ import scalaz.syntax.monad._
 import scalaz.syntax.monoid._
 import scala.collection.generic.CanBuildFrom
 import scalaz.MonadTell
-import paperdoll.core.effect.Translator
+import paperdoll.core.effect.PureTranslator
 import paperdoll.core.layer.Layer
 import paperdoll.core.layer.Member
 import paperdoll.core.layer.Subset
@@ -56,8 +56,8 @@ object WriterLayer {
   }
 
   def translateWriter[F[_], W](
-    implicit mt: MonadTell[F, W]): Translator.Aux[Writer_[W], Layer.Aux[F] :+: CNil, Layers.One[Layer.Aux[F]]] =
-    new Translator[Writer_[W]] {
+    implicit mt: MonadTell[F, W]): PureTranslator.Aux[Writer_[W], Layer.Aux[F] :+: CNil, Layers.One[Layer.Aux[F]]] =
+    new PureTranslator[Writer_[W]] {
       override type OR = Layer.Aux[F] :+: CNil
       override type OL = Layers.One[Layer.Aux[F]]
       override def run[R <: Coproduct, L1 <: Layers[R], RR <: Coproduct, RL <: Layers[RR], A](eff: Effects[R, L1, A])(

--- a/scalaz/src/main/scala/paperdoll/scalaz/WriterLayer.scala
+++ b/scalaz/src/main/scala/paperdoll/scalaz/WriterLayer.scala
@@ -4,7 +4,6 @@ import shapeless.{ :+:, CNil, Coproduct }
 import scalaz.{ Monoid, Writer }
 import paperdoll.core.effect.{ Effects, Arr, PureBind, PureHandler }
 import paperdoll.core.effect.Effects.sendU
-import paperdoll.core.effect.Arrs.compose
 import paperdoll.core.layer.Layers
 import scalaz.syntax.monad._
 import scalaz.syntax.monoid._
@@ -14,12 +13,6 @@ import paperdoll.core.effect.PureTranslator
 import paperdoll.core.layer.Layer
 import paperdoll.core.layer.Member
 import paperdoll.core.layer.Subset
-import paperdoll.core.effect.Pure
-import scalaz.Forall
-import paperdoll.core.effect.Arrs
-import paperdoll.core.effect.Arr_
-import paperdoll.core.effect.Impure
-import paperdoll.core.queue.Queue
 import paperdoll.core.effect.Loop
 import paperdoll.core.effect.Handler
 

--- a/std/src/main/scala/paperdoll/std/EitherLayer.scala
+++ b/std/src/main/scala/paperdoll/std/EitherLayer.scala
@@ -1,7 +1,7 @@
 package paperdoll.std
 
-import paperdoll.core.effect.Bind
-import paperdoll.core.effect.Handler
+import paperdoll.core.effect.PureBind
+import paperdoll.core.effect.PureHandler
 import paperdoll.core.effect.Effects
 import paperdoll.core.effect.Effects.sendU
 import paperdoll.core.effect.Arr
@@ -17,8 +17,8 @@ object EitherLayer {
   /** Either is handled much like Option: if Right,
    *  run the continuation, if Left, return that.
    */
-  def handleEither[A]: Handler.Aux[Either_[A], Either_[A]#F] =
-    new Bind[Either_[A]] {
+  def handleEither[A]: PureHandler.Aux[Either_[A], Either_[A]#F] =
+    new PureBind[Either_[A]] {
       override type O[X] = Either[A, X]
       override def pure[B](b: B) = Right(b)
       override def bind[V, RR <: Coproduct, RL <: Layers[RR], B](eff: Either[A, V], cont: Arr[RR, RL, V, Either[A, B]]) =

--- a/std/src/main/scala/paperdoll/std/OptionLayer.scala
+++ b/std/src/main/scala/paperdoll/std/OptionLayer.scala
@@ -1,7 +1,7 @@
 package paperdoll.std
 
-import paperdoll.core.effect.Bind
-import paperdoll.core.effect.Handler
+import paperdoll.core.effect.PureBind
+import paperdoll.core.effect.PureHandler
 import paperdoll.core.effect.Effects
 import paperdoll.core.effect.Arr
 import paperdoll.core.effect.Pure
@@ -12,8 +12,8 @@ object OptionLayer {
   /** Options are handled by: if Some, run the continuation, otherwise
    *  return Pure(None)
    */
-  def handleOption: Handler.Aux[Option_, Option] =
-    new Bind[Option_] {
+  def handleOption: PureHandler.Aux[Option_, Option] =
+    new PureBind[Option_] {
       override type O[X] = Option[X]
       override def pure[A](a: A) = Some(a)
       override def bind[V, RR <: Coproduct, RL <: Layers[RR], A](eff: Option[V], cont: Arr[RR, RL, V, Option[A]]) =

--- a/std/src/main/scala/paperdoll/std/TryLayer.scala
+++ b/std/src/main/scala/paperdoll/std/TryLayer.scala
@@ -3,8 +3,8 @@ package paperdoll.std
 import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
-import paperdoll.core.effect.Bind
-import paperdoll.core.effect.Handler
+import paperdoll.core.effect.PureBind
+import paperdoll.core.effect.PureHandler
 import paperdoll.core.effect.Pure
 import paperdoll.core.layer.Layers
 import shapeless.Coproduct
@@ -14,8 +14,8 @@ object TryLayer {
   /** Try is handled much like Option: if Success,
    *  run the continuation, if Failure, return that.
    */
-  def runTry: Handler.Aux[Try_, Try] =
-    new Bind[Try_] {
+  def runTry: PureHandler.Aux[Try_, Try] =
+    new PureBind[Try_] {
       override type O[X] = Try[X]
       override def pure[A](b: A) = Success(b)
       override def bind[V, RR <: Coproduct, RL <: Layers[RR], A](eff: Try[V], cont: Arr[RR, RL, V, Try[A]]) =


### PR DESCRIPTION
Should hopefully make it simpler to implement more translators.
